### PR TITLE
Add contract for user registrations and logins

### DIFF
--- a/contracts/Users.sol
+++ b/contracts/Users.sol
@@ -1,0 +1,35 @@
+pragma solidity >=0.4.21 <0.7.0;
+
+contract Users
+{
+    struct User {
+        string email;
+        bytes32 password;
+        bool registered;
+        // Add any data here about the voter that we also need
+    }
+
+    mapping(string => User) private users;
+
+    function register(string memory email, string memory password) public returns (bool) {
+        // Check if user is already registered
+        if (users[email].registered == true) {
+            return false;
+        }
+
+        // Register user data
+        users[email].email = email;
+        users[email].password = keccak256(abi.encodePacked(password)); // Store hashed for security and later comparisons.
+        users[email].registered = true;
+
+        return true; // Registration success
+    }
+
+    function login(string memory email, string memory password) public view returns (bool) {
+        if (users[email].password == keccak256(abi.encodePacked(password))) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/contracts/Users.sol
+++ b/contracts/Users.sol
@@ -1,5 +1,10 @@
 pragma solidity >=0.4.21 <0.7.0;
 
+// Facilitates registration of new users with an email and password.
+// Stores the password as a secured byte hash.
+// Allows for login verification by providing an email and password to check
+// against the stored user database on the blockchain.
+
 contract Users
 {
     struct User {
@@ -13,7 +18,7 @@ contract Users
 
     function register(string memory email, string memory password) public returns (bool) {
         // Check if user is already registered
-        if (users[email].registered == true) {
+        if (exists(email)) {
             return false;
         }
 
@@ -31,5 +36,9 @@ contract Users
         } else {
             return false;
         }
+    }
+
+    function exists(string memory email) public view returns (bool) {
+        return users[email].registered;
     }
 }

--- a/contracts/tests/UsersTest.sol
+++ b/contracts/tests/UsersTest.sol
@@ -1,0 +1,25 @@
+pragma solidity >=0.4.21 <0.7.0;
+
+import "remix_tests.sol"; // this import is automatically injected by Remix.
+import "../contracts/Users.sol";
+
+contract UsersTest {
+    Users users;
+
+    function beforeAll () public {
+        users = new Users();
+    }
+
+    function registerUsers() public {
+        Assert.equal(users.register("test1@site.com", "password123"), true, "test1@site.com should be able to register.");
+        Assert.equal(users.register("test1@site.com", "password123"), false, "test1@site.com should not be able to register twice.");
+        Assert.equal(users.register("test2@site.com", "456Password"), true, "test2@site.com should be able to register.");
+    }
+
+    function loginUsers() public {
+        Assert.equal(users.login("test1@site.com", "wrongPassword"), false, "test1@site.com should not be able to login with a wrong password.");
+        Assert.equal(users.login("test1@site.com", "password123"), true, "test1@site.com should be able to login with the correct password.");
+        Assert.equal(users.login("test2@site.com", "456password"), false, "test2@site.com should not be able to login with a wrong password due to case sensitivity.");
+        Assert.equal(users.login("test2@site.com", "456Password"), true, "test2@site.com should be able to login with the correct password.");
+    }
+}


### PR DESCRIPTION
Adds a smart contract for registering users with an email and password, which is stored as a secure byte hash on the blockchain.
Allows for logins to be verified with the login method, providing it an email and password which will be compared against the currently registered users and return true if the password is correct for that user.

We may still want to add more to the `User` struct for any voting details, like affiliation. Or, alternatively, this could be used in the voting contracts struct.