### PR TITLE
Store admin key as a hashed value to not expose it

### DIFF
--- a/contracts/VoteTracker.sol
+++ b/contracts/VoteTracker.sol
@@ -4,7 +4,7 @@ import "./VoteLibrary.sol";
 
 contract VoteTracker
 {
-    string public secret = "123456";
+    bytes32 adminKey = 0xc888c9ce9e098d5864d3ded6ebcc140a12142263bace3a23a36f9905f12bd64a;
 
     mapping(uint => VoteLibrary.Vote) public VoteStore;
     uint256 public voterCount = 0;
@@ -50,9 +50,11 @@ contract VoteTracker
         emit PartyCreate(_name, 0);
     }
 
-    function getAdminKey() public returns(string memory)
+    function verifyAdminKey(string memory _key) public returns(bool)
     {
-        return secret;
+        require(adminKey == keccak256(abi.encodePacked(_key)));
+        
+        return true;
     }
 
     function checkIfCanExist(string memory _namer) private returns(bool)

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -117,19 +117,17 @@ function register() {
 }
 
 function adminLogin() {
-    var key;
-    VoteTrackerContract.methods.getAdminKey()
-        .call((error, response) => {
-            if (error) {
-                console.log(error);
-            } else {
-                key = response;
-                var pass = document.getElementById("password").value;
-                if (pass == key) {
-                    window.location.href = "./PartyRegistration.html";
-                } else {
-                    alert("Wrong Key");
-                }
-            }
-        });
+    var key = document.getElementById("password").value;
+
+    VoteTrackerContract.methods.verifyAdminKey(key)
+    .send()
+    .then(result => {
+        if (result.status === true) {
+            window.location.href = "./PartyRegistration.html";
+        } else {
+            alert("Incorrect admin key.");
+        }
+    }).catch(err => {
+        alert("Incorrect admin key.");
+    });
 }


### PR DESCRIPTION
Changes the admin key (123456) from being stored in plaintext to being a hashed value that is compared against.

Further security against admin-only actions may need to be added, such as verifying the admin PIN again on the party registration page before allowing a party to be added.